### PR TITLE
Fix for subprojects

### DIFF
--- a/src/main/java/com/tony/support/GradleTreeParser.java
+++ b/src/main/java/com/tony/support/GradleTreeParser.java
@@ -114,6 +114,9 @@ public class GradleTreeParser {
             artifactId = gaItem[1];
         } else {
             String[] gaItem = StringUtils.splitByWholeSeparator(coordinate, ":");
+            if (gaItem.length < 2) {
+                gaItem = StringUtils.splitByWholeSeparator(coordinate, " ");
+            }
             groupId = gaItem[0];
             artifactId = gaItem[1];
             if (gaItem.length < 3) {


### PR DESCRIPTION
If you have a subproject as a dependency, you end up with something like `coordinate = "project my-sub-project (n)"` without a `:` separator. So to get around that I've added another `split` command.